### PR TITLE
fix: correctly retry if no reservations found

### DIFF
--- a/src/main/scala/com/resy/ResyClient.scala
+++ b/src/main/scala/com/resy/ResyClient.scala
@@ -59,9 +59,9 @@ class ResyClient(resyApi: ResyApi) {
     val timeLeftToRetry = millisToRetry - (DateTime.now.getMillis - dateTimeStart)
 
     reservationTimesResp match {
-      case Success(reservationTimes) =>
+      case Success(reservationTimes) if reservationTimes.nonEmpty =>
         findReservationTime(reservationTimes, resTimeTypes)
-      case Failure(_) if timeLeftToRetry > 0 =>
+      case _ if timeLeftToRetry > 0 =>
         retryFindReservation(date, partySize, venueId, resTimeTypes, timeLeftToRetry)
       case _ =>
         Failure(new RuntimeException(cantFindResMsg))

--- a/src/test/resources/getReservationsNoneAvailable.json
+++ b/src/test/resources/getReservationsNoneAvailable.json
@@ -1,0 +1,9 @@
+{
+  "results": {
+    "venues": [
+      {
+        "slots": []
+      }
+    ]
+  }
+}


### PR DESCRIPTION
There was a bug that I introduced at some point where if the first query for reservations returned that none were available, the bot would immediately kill itself. This change should now correctly continue querying for reservations until it reaches the max `millisToRetry`.

- [x] Should now correctly retry searching for reservations as long as none were found or it has not hit the max `millisToRetry`