### PR TITLE
added more logging in ResyClient.scala

### DIFF
--- a/src/main/scala/com/resy/ResyClient.scala
+++ b/src/main/scala/com/resy/ResyClient.scala
@@ -186,6 +186,9 @@ class ResyClient(resyApi: ResyApi) extends Logging {
       case None if resTimeTypes.tail.nonEmpty =>
         findReservationTime(reservationMap, resTimeTypes.tail)
       case _ =>
+        logger.info("Missed the shot!")
+        logger.info("""┻━┻ ︵ \(°□°)/ ︵ ┻━┻""")
+        logger.info(cantFindResMsg)
         Failure(new RuntimeException(cantFindResMsg))
     }
   }


### PR DESCRIPTION
Added a few more log statements in `ResyClient.scala` as it would sometimes fail to get a reservation but give no indication in the output that it actually failed.

- [x] Added more logging in `ResyClient.scala`