### PR TITLE
feat: allow retrying snipes

### DIFF
--- a/src/main/scala/com/resy/ResyBookingWorkflow.scala
+++ b/src/main/scala/com/resy/ResyBookingWorkflow.scala
@@ -1,20 +1,28 @@
 package com.resy
 
 import org.apache.logging.log4j.scala.Logging
+import org.joda.time.DateTime
 
-import scala.util.Try
+import scala.annotation.tailrec
+import scala.concurrent.duration._
+import scala.language.postfixOps
+import scala.util.{Failure, Try}
 
 object ResyBookingWorkflow extends Logging {
 
+  @tailrec
   def run(
     resyClient: ResyClient,
-    resDetails: ReservationDetails
+    resDetails: ReservationDetails,
+    millisToRetry: Long = (10 seconds).toMillis
   ): Try[String] = {
+    val dateTimeStart = DateTime.now.getMillis
+
     logger.info("Taking the shot...")
     logger.info("(҂‾ ▵‾)︻デ═一 (˚▽˚’!)/")
     logger.info(s"Attempting to snipe reservation")
 
-    for {
+    val maybeResyTokenResp = for {
       configId <- resyClient.retryFindReservation(
         date         = resDetails.date,
         partySize    = resDetails.partySize,
@@ -31,5 +39,13 @@ object ResyBookingWorkflow extends Logging {
         bookingDetails.bookingToken
       )
     } yield resyToken
+
+    val timeLeftToRetry = millisToRetry - (DateTime.now.getMillis - dateTimeStart)
+
+    maybeResyTokenResp match {
+      case Failure(_) if timeLeftToRetry > 0 =>
+        run(resyClient: ResyClient, resDetails, timeLeftToRetry)
+      case maybeResyToken => maybeResyToken
+    }
   }
 }

--- a/src/test/scala/com/resy/ResyBookingWorkflowSpec.scala
+++ b/src/test/scala/com/resy/ResyBookingWorkflowSpec.scala
@@ -33,6 +33,40 @@ class ResyBookingWorkflowSpec extends AnyFlatSpec with Matchers {
     ResyBookingWorkflow.run(resyClient, resDetails) shouldEqual Success("RESY_TOKEN")
   }
 
+  it should "find and book an available reservation with retrying" in new Fixture {
+    when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
+      .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
+
+    when(resyApi.getReservationDetails(configId, resDetails.date, resDetails.partySize))
+      .thenReturn(Future(Source.fromResource("getReservationDetails.json").mkString))
+
+    when(resyApi.postReservation(paymentMethodId, bookToken))
+      .thenReturn(Future(""))
+      .thenReturn(Future(Source.fromResource("bookReservation.json").mkString))
+
+    ResyBookingWorkflow.run(resyClient, resDetails) shouldEqual Success("RESY_TOKEN")
+
+    verify(resyApi, Mockito.times(2))
+      .getReservations(
+        date      = resDetails.date,
+        partySize = resDetails.partySize,
+        venueId   = resDetails.venueId
+      )
+
+    verify(resyApi, Mockito.times(2))
+      .getReservationDetails(
+        configId  = configId,
+        date      = resDetails.date,
+        partySize = resDetails.partySize
+      )
+
+    verify(resyApi, Mockito.times(2))
+      .postReservation(
+        paymentMethodId = paymentMethodId,
+        bookToken       = bookToken
+      )
+  }
+
   it should "find but fail to book an available reservation" in new Fixture {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
@@ -43,7 +77,7 @@ class ResyBookingWorkflowSpec extends AnyFlatSpec with Matchers {
     when(resyApi.postReservation(paymentMethodId, bookToken))
       .thenReturn(Future(""))
 
-    ResyBookingWorkflow.run(resyClient, resDetails) match {
+    ResyBookingWorkflow.run(resyClient, resDetails, 0) match {
       case Failure(exception) =>
         withClue("RuntimeException not found:") {
           exception.isInstanceOf[RuntimeException] shouldEqual true


### PR DESCRIPTION
There can be a case where someone else can snipe a reservation before you get to snipe it. This change allows you to set a timeout for how long it should continue trying to snipe for reservations.

- [x] Add configurable max time to continue trying to snipe for reservations