### PR TITLE
feat: short circuit if no reservation found

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,46 @@ snipe a reservation. It will attempt to grab a reservation for a couple of secon
 it was or wasn't successful in getting a reservation.
 
 ## Usage
-You need to provide a few values before running the bot.  These values are located in the ResyBookingBot object at the
-top. There are comments above the variables with what needs to be provided before it can be used, but I'll list it here
-as well for clarity.
-* apiKey - Your user profile API key. Can be found when logging into Resy if you have the web console open  in your 
-* headers called `authorization`.
-* auth_token - Your user profile authentication token when logging into Resy. Can be found when logging into Resy if 
-you have the web console open in your headers called `x-resy-auth-token`.
-* date - The date you want to make the reservation in YYYY-MM-DD format.  This should be set to the day after the last 
-available day with restaurant reservations as this is the day you want to snipe for a reservation once they become 
+You need to provide a few values before running the bot.  These values are located in the `ResyBookingBot` object at 
+the top. There are comments above the variables with what needs to be provided before it can be used, but I'll list it 
+here as well for clarity.
+* **apiKey** - Your user profile API key. Can be found when logging into Resy if you have the web console open  in your 
+ headers called `authorization`.
+* **auth_token** - Your user profile authentication token when logging into Resy. Can be found when logging into Resy 
+if you have the web console open in your headers called `x-resy-auth-token`.
+* **date** - The date you want to make the reservation in YYYY-MM-DD format.  This should be set to the day after the 
+last available day with restaurant reservations as this is the day you want to snipe for a reservation once they become 
 available.
-* partySize - Size of the party reservation
-* venueId - The id of the restaurant you want to make the reservation at.  Can be found when viewing available
+* **partySize** - Size of the party reservation
+* **venueId** - The id of the restaurant you want to make the reservation at.  Can be found when viewing available
 reservations for a restaurant if you have the web console open.
-* resTimeTypes - Priority list of reservation times and table types. Time is in military time HH:MM:SS format. This 
+* **resTimeTypes** - Priority list of reservation times and table types. Time is in military time HH:MM:SS format. This 
 allows full flexibility on your reservation preferences. For example, your priority order of reservations can be...
   * 17:00 - Patio
   * 18:00 - Indoor
   * 17:30 - Patio
 
   If you have no preference on table type, then simply don't set it and the bot will pick from whatever is available.
-* hour - Hour of the day when reservations become available and when you want to snipe
-* minute - Minute of the day when reservations become available and when you want to snipe
+* **hour** - Hour of the day when reservations become available and when you want to snipe
+* **minute** - Minute of the day when reservations become available and when you want to snipe
 
-The main entry point of the bot is in ResyBookingBot under the main function. Upon running the bot, it will
+## How it works
+The main entry point of the bot is in the `ResyBookingBot` object under the `main` function. Upon running the bot, it 
+will
 automatically sleep until the specified time. At the specified time, it will wake up and attempt to query for 
 reservations for 10 seconds. This is because sometimes reservations are not available exactly at the same time every
-day so 10 seconds is to allow for some buffer. Once times are retrieved, it will try to find the best available time
-slot given your priority list of reservation times. If a time can be booked, it will make an attempt to snipe it.
-Otherwise, it will report that it was unable to acquire a reservation. In the event it was unable to get any
-reservations for 10 seconds, the bot will automatically shutdown.
+day so 10 seconds is to allow for some buffer. Once reservation times are retrieved, it will try to find the best 
+available time slot given your priority list of reservation times. If a time can't be booked, the bot will shutdown 
+here. If a time can be booked, it will make an attempt to snipe it. If a reservation couldn't be booked, and it's still 
+within 10 seconds of the original start time, it will restart the whole workflow and try to find another available 
+reservation. In the event it was unable to get any reservations, the bot will automatically shutdown.
+
+## Running the bot
+There are a multitude of ways to run it, but I'll share the two most 
+common ways:
+- You can use the `Run` button in IntelliJ. It may automatically be able to find the main class. If not, you have to 
+configure it to look under `com.resy.ResyBookingBot`.
+- You can run it via `sbt`. I would recommend doing this via CLI instead of inside IntelliJ. Type `sbt` to start the  
+sbt instance, then type `run`. It will have some output then bring you back to the sbt prompt. Do not exit out of the 
+sbt prompt as this will kill the bot. The bot is running inside the sbt instance and will wake up at the appropriate 
+time to snipe a reservation.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ last available day with restaurant reservations as this is the day you want to s
 available.
 * **partySize** - Size of the party reservation
 * **venueId** - The id of the restaurant you want to make the reservation at.  Can be found when viewing available
-reservations for a restaurant if you have the web console open.
+reservations for a restaurant as a query parameter in the `/find` API call if you have the web console open.
 * **resTimeTypes** - Priority list of reservation times and table types. Time is in military time HH:MM:SS format. This 
 allows full flexibility on your reservation preferences. For example, your priority order of reservations can be...
   * 17:00 - Patio

--- a/src/main/scala/com/resy/ResyBookingBot.scala
+++ b/src/main/scala/com/resy/ResyBookingBot.scala
@@ -41,8 +41,9 @@ object ResyBookingBot extends Logging {
   def main(args: Array[String]): Unit = {
     logger.info("Starting Resy Booking Bot")
 
-    val resyApi    = new ResyApi(resyKeys)
-    val resyClient = new ResyClient(resyApi)
+    val resyApi             = new ResyApi(resyKeys)
+    val resyClient          = new ResyClient(resyApi)
+    val resyBookingWorkflow = new ResyBookingWorkflow(resyClient, resDetails)
 
     val system      = ActorSystem("System")
     val dateTimeNow = DateTime.now
@@ -68,7 +69,7 @@ object ResyBookingBot extends Logging {
     )
 
     system.scheduler.scheduleOnce(millisUntilTomorrow millis) {
-      ResyBookingWorkflow.run(resyClient, resDetails)
+      resyBookingWorkflow.run()
 
       logger.info("Shutting down Resy Booking Bot")
       System.exit(0)

--- a/src/main/scala/com/resy/ResyBookingWorkflow.scala
+++ b/src/main/scala/com/resy/ResyBookingWorkflow.scala
@@ -6,29 +6,45 @@ import org.joda.time.DateTime
 import scala.annotation.tailrec
 import scala.concurrent.duration._
 import scala.language.postfixOps
-import scala.util.{Failure, Try}
+import scala.util.{Failure, Success, Try}
 
-object ResyBookingWorkflow extends Logging {
+class ResyBookingWorkflow(resyClient: ResyClient, resDetails: ReservationDetails) extends Logging {
+
+  def run(millisToRetry: Long = (10 seconds).toMillis): Try[String] =
+    runnable(millisToRetry, DateTime.now.getMillis)
 
   @tailrec
-  def run(
-    resyClient: ResyClient,
-    resDetails: ReservationDetails,
-    millisToRetry: Long = (10 seconds).toMillis
-  ): Try[String] = {
-    val dateTimeStart = DateTime.now.getMillis
-
+  private[this] def runnable(millisToRetry: Long, dateTimeStart: Long): Try[String] = {
     logger.info("Taking the shot...")
     logger.info("(҂‾ ▵‾)︻デ═一 (˚▽˚’!)/")
     logger.info(s"Attempting to snipe reservation")
 
-    val maybeResyTokenResp = for {
-      configId <- resyClient.retryFindReservation(
-        date         = resDetails.date,
-        partySize    = resDetails.partySize,
-        venueId      = resDetails.venueId,
-        resTimeTypes = resDetails.resTimeTypes
-      )
+    val maybeConfigId = resyClient.findReservations(
+      date         = resDetails.date,
+      partySize    = resDetails.partySize,
+      venueId      = resDetails.venueId,
+      resTimeTypes = resDetails.resTimeTypes
+    )
+
+    maybeConfigId match {
+      case Success(configId) =>
+        val maybeResyTokenResp = snipeReservation(resyClient, resDetails, configId)
+
+        maybeResyTokenResp match {
+          case Failure(_) if millisToRetry > DateTime.now.getMillis - dateTimeStart =>
+            runnable(dateTimeStart, millisToRetry)
+          case maybeResyToken => maybeResyToken
+        }
+      case error => error
+    }
+  }
+
+  private[this] def snipeReservation(
+    resyClient: ResyClient,
+    resDetails: ReservationDetails,
+    configId: String
+  ): Try[String] = {
+    for {
       bookingDetails <- resyClient.getReservationDetails(
         configId  = configId,
         date      = resDetails.date,
@@ -39,13 +55,5 @@ object ResyBookingWorkflow extends Logging {
         bookingDetails.bookingToken
       )
     } yield resyToken
-
-    val timeLeftToRetry = millisToRetry - (DateTime.now.getMillis - dateTimeStart)
-
-    maybeResyTokenResp match {
-      case Failure(_) if timeLeftToRetry > 0 =>
-        run(resyClient: ResyClient, resDetails, timeLeftToRetry)
-      case maybeResyToken => maybeResyToken
-    }
   }
 }

--- a/src/test/resources/log4j2.properties
+++ b/src/test/resources/log4j2.properties
@@ -1,0 +1,9 @@
+status = debug
+
+rootLogger.level = debug
+rootLogger.appenderRef.stdout.ref = Stdout
+
+appender.console.type = Console
+appender.console.name = Stdout
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSSXXX} %c{1}:%L - %msg%n

--- a/src/test/scala/com/resy/ResyClientSpec.scala
+++ b/src/test/scala/com/resy/ResyClientSpec.scala
@@ -26,7 +26,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date          = resDetails.date,
       partySize     = resDetails.partySize,
       venueId       = resDetails.venueId,
@@ -39,7 +39,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date      = resDetails.date,
       partySize = resDetails.partySize,
       venueId   = resDetails.venueId,
@@ -55,7 +55,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date      = resDetails.date,
       partySize = resDetails.partySize,
       venueId   = resDetails.venueId,
@@ -70,7 +70,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date      = resDetails.date,
       partySize = resDetails.partySize,
       venueId   = resDetails.venueId,
@@ -85,7 +85,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date      = resDetails.date,
       partySize = resDetails.partySize,
       venueId   = resDetails.venueId,
@@ -101,7 +101,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
       .thenReturn(Future(""))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date          = resDetails.date,
       partySize     = resDetails.partySize,
       venueId       = resDetails.venueId,
@@ -122,7 +122,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
       .thenReturn(Future(Source.fromResource("getReservationsNoneAvailable.json").mkString))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date          = resDetails.date,
       partySize     = resDetails.partySize,
       venueId       = resDetails.venueId,
@@ -142,7 +142,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(""))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date          = resDetails.date,
       partySize     = resDetails.partySize,
       venueId       = resDetails.venueId,
@@ -153,7 +153,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
         withClue("RuntimeException not found:") {
           exception.isInstanceOf[RuntimeException] shouldEqual true
         }
-        exception.getMessage shouldEqual ResyClientErrorMessages.cantFindResMsg
+        exception.getMessage shouldEqual ResyClientErrorMessages.noAvailableResMsg
       case _ =>
         fail("Failure not found")
     }
@@ -163,7 +163,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date         = resDetails.date,
       partySize    = resDetails.partySize,
       venueId      = resDetails.venueId,
@@ -183,7 +183,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date         = resDetails.date,
       partySize    = resDetails.partySize,
       venueId      = resDetails.venueId,
@@ -203,7 +203,7 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
-    resyClient.retryFindReservation(
+    resyClient.findReservations(
       date         = resDetails.date,
       partySize    = resDetails.partySize,
       venueId      = resDetails.venueId,

--- a/src/test/scala/com/resy/ValidateJsonStubSpec.scala
+++ b/src/test/scala/com/resy/ValidateJsonStubSpec.scala
@@ -13,8 +13,10 @@ class ValidateJsonStubSpec extends AnyFlatSpec with Matchers with Logging {
 
   behavior of "ValidateJsonStubSpec"
   it should "validate JSON stubs are valid JSON" in {
-    val rootPath  = new File(".").getCanonicalPath
-    val jsonFiles = new File(s"$rootPath/src/test/resources").listFiles.toSeq
+    val rootPath = new File(".").getCanonicalPath
+    val jsonFiles =
+      new File(s"$rootPath/src/test/resources").listFiles.toSeq
+        .filter(_.getName.endsWith(".json"))
 
     for {
       jsonFile <- jsonFiles


### PR DESCRIPTION
When getting a list of reservations for the restaurants and none match the user's preferred times and/or table types, the bot can end here as there is no reason to continue querying.

- [x] Bot will shutdown early if no available reservation matches the user's preferred times and/or table types
- [x] Tweaked timeouts to be more accurate in determining TTL and to no longer recalculate start times on recursive calls
- [x] Added better error messaging
- [x] Added separate log4j config when running tests
- [x] Updated and improved documentation