### PR TITLE
ci: minor cleanup to auto release config

### DIFF
--- a/.autorc.json
+++ b/.autorc.json
@@ -87,7 +87,8 @@
       "changelogTitle": "🏠 Chores",
       "description": "Other changes that don't modify src or test files",
       "releaseType": "none",
-      "color": "#964B00"
+      "color": "#964B00",
+      "default": true
     },
     {
       "name": "revert",

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: Release
 
 on:
   workflow_dispatch:
-  pull_request:
   workflow_run:
     workflows: [CI]
     types: [completed]


### PR DESCRIPTION
It's hard to test auto without merging to master so needed to make a few non-user impacting fixes

- [x] Defaulted PRs to the chores label if not defined
- [x] The release should not run on PRs