### PR TITLE
feat!: separate out config from driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ snipe a reservation. It will attempt to grab a reservation for a couple of secon
 it was or wasn't successful in getting a reservation.
 
 ## Usage
-You need to provide a few values before running the bot.  These values are located in the `ResyBookingBot` object at 
-the top. There are comments above the variables with what needs to be provided before it can be used, but I'll list it 
+You need to provide a few values before running the bot.  These values are located in the `ResyConfig` object. There 
+are comments above the variables with what needs to be provided before it can be used, but I'll list it 
 here as well for clarity.
 * **apiKey** - Your user profile API key. Can be found when logging into Resy if you have the web console open  in your 
  headers called `authorization`.
@@ -35,15 +35,15 @@ allows full flexibility on your reservation preferences. For example, your prior
 * **minute** - Minute of the day when reservations become available and when you want to snipe
 
 ## How it works
-The main entry point of the bot is in the `ResyBookingBot` object under the `main` function. The bot runs based on the 
-local time of the machine it's running on. Upon running the bot, it will automatically sleep until the specified time. 
-At the specified time, it will wake up and attempt to query for reservations for 10 seconds. This is because sometimes 
-reservations are not available exactly at the same time every day so 10 seconds is to allow for some buffer. Once 
-reservation times are retrieved, it will try to find the best available time slot given your priority list of 
-reservation times. If a time can't be booked, the bot will shutdown here. If a time can be booked, it will make an 
-attempt to snipe it. If a reservation couldn't be booked, and it's still within 10 seconds of the original start time, 
-it will restart the whole workflow and try to find another available reservation. In the event it was unable to get any 
-reservations, the bot will automatically shutdown.
+The main entry point of the bot is in the `ResyBookingBot` object under the `main` function. It utilizes the arguments 
+which you need to provide under the `ResyConfig` object.  The bot runs based on the local time of the machine it's 
+running on. Upon running the bot, it will automatically sleep until the specified time. At the specified time, it will 
+wake up and attempt to query for reservations for 10 seconds. This is because sometimes reservations are not available 
+exactly at the same time every day so 10 seconds is to allow for some buffer. Once reservation times are retrieved, it 
+will try to find the best available time slot given your priority list of reservation times. If a time can't be booked, 
+the bot will shutdown here. If a time can be booked, it will make an attempt to snipe it. If a reservation couldn't be 
+booked, and it's still within 10 seconds of the original start time, it will restart the whole workflow and try to find 
+another available reservation. In the event it was unable to get any reservations, the bot will automatically shutdown.
 
 ## Running the bot
 There are a multitude of ways to run it, but I'll share the two most 

--- a/src/main/scala/com/resy/ResyBookingBot.scala
+++ b/src/main/scala/com/resy/ResyBookingBot.scala
@@ -1,6 +1,7 @@
 package com.resy
 
 import akka.actor.ActorSystem
+import com.resy.ResyConfig._
 import org.apache.logging.log4j.scala.Logging
 import org.joda.time.DateTime
 
@@ -9,34 +10,6 @@ import scala.concurrent.duration._
 import scala.language.postfixOps
 
 object ResyBookingBot extends Logging {
-
-  private val resyKeys = ResyKeys(
-    // Your user profile API key which can be found via your browser web console in your headers
-    // called "authorization"
-    apiKey = ???,
-    // Your user profile authentication token which can be found via your browser web console in
-    // your headers called "x-resy-auth-token"
-    authToken = ???
-  )
-
-  private val resDetails = ReservationDetails(
-    // Date of the reservation in YYYY-MM-DD format
-    date = ???,
-    // Size of the party reservation
-    partySize = ???,
-    // Unique identifier of the restaurant where you want to make the reservation
-    venueId = ???,
-    // Priority list of reservation times and table types. Time is in military time HH:MM:SS format.
-    // If no preference on table type, then simply don't set it.
-    resTimeTypes = ???
-  )
-
-  private val snipeTime = SnipeTime(
-    // Hour of the day when reservations become available and when you want to snipe
-    hours = ???,
-    // Minute of the day when reservations become available and when you want to snipe
-    minutes = ???
-  )
 
   def main(args: Array[String]): Unit = {
     logger.info("Starting Resy Booking Bot")

--- a/src/main/scala/com/resy/ResyConfig.scala
+++ b/src/main/scala/com/resy/ResyConfig.scala
@@ -1,0 +1,32 @@
+package com.resy
+
+object ResyConfig {
+
+  val resyKeys: ResyKeys = ResyKeys(
+    // Your user profile API key which can be found via your browser web console in your headers
+    // called "authorization"
+    apiKey = ???,
+    // Your user profile authentication token which can be found via your browser web console in
+    // your headers called "x-resy-auth-token"
+    authToken = ???
+  )
+
+  val resDetails: ReservationDetails = ReservationDetails(
+    // Date of the reservation in YYYY-MM-DD format
+    date = ???,
+    // Size of the party reservation
+    partySize = ???,
+    // Unique identifier of the restaurant where you want to make the reservation
+    venueId = ???,
+    // Priority list of reservation times and table types. Time is in military time HH:MM:SS format.
+    // If no preference on table type, then simply don't set it.
+    resTimeTypes = ???
+  )
+
+  val snipeTime: SnipeTime = SnipeTime(
+    // Hour of the day when reservations become available and when you want to snipe
+    hours = ???,
+    // Minute of the day when reservations become available and when you want to snipe
+    minutes = ???
+  )
+}


### PR DESCRIPTION
Currently, the config vals and the driver live in the same code. The config vals is ideally the interface for the user. So it can be annoying for me to make changes to the driver code that impacts the execution of the bot but doesn't impact how you run it from the user perspective. So to have a better separation of concerns, I've moved the config out to a separate file from the driver code. This way, changes to the driver can have minimal impact on how the bot is run. The config should mostly remain untouched so future improvements will not cause merge conflicts.

- [x] Driver code and config are now separate files