### PR TITLE
fix: increase timeout to avoid false negatives

### DIFF
--- a/src/main/scala/com/resy/ResyClient.scala
+++ b/src/main/scala/com/resy/ResyClient.scala
@@ -113,7 +113,7 @@ class ResyClient(resyApi: ResyApi) extends Logging {
     val resyTokenResp = Try {
       val response = Await.result(
         awaitable = resyApi.postReservation(paymentMethodId, bookToken),
-        atMost    = 5 seconds
+        atMost    = 10 seconds
       )
 
       logger.debug(s"URL Response: $response")


### PR DESCRIPTION
Sometimes the book API call can take longer than 5 seconds to respond back. So increasing the timeout to avoid incorrectly erroring out that a reservation was not found when in fact, it could have been.

- [x] Increase book reservation API call timeout from 5 to 10 seconds