### PR TITLE
add option of Docker-based build and execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM sbtscala/scala-sbt:openjdk-18.0.2.1_1.8.0_3.2.0
+
+COPY src/main/scala/ /app/src/main/scala
+
+COPY project/ /app/project
+
+COPY build.sbt /app/build.sbt
+
+WORKDIR /app/
+
+RUN sbt update
+
+RUN sbt compile
+
+CMD sbt run

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+run: build
+	docker run -it --rm --volume=${CURDIR}/src/main/resources:/app/src/main/resources:Z resy-booking-bot
+
+build:
+	docker build -t resy-booking-bot .

--- a/README.md
+++ b/README.md
@@ -62,3 +62,4 @@ configure it to look under `com.resy.ResyBookingBot`.
 sbt instance, then type `run`. It will have some output then bring you back to the sbt prompt. Do not exit out of the 
 sbt prompt as this will kill the bot. The bot is running inside the sbt instance and will wake up at the appropriate 
 time to snipe a reservation.
+- You can run it with Make and Docker by running `make`


### PR DESCRIPTION
I don't have IntelliJ and don't want to install any of the Scala tools anywhere, so I containerized this. 