### PR TITLE
perf: updated to snipe 2 seconds sooner

### DIFF
--- a/src/main/scala/com/resy/ResyBookingBot.scala
+++ b/src/main/scala/com/resy/ResyBookingBot.scala
@@ -36,7 +36,7 @@ object ResyBookingBot extends Logging {
       if (todaysSnipeTime.getMillis > dateTimeNow.getMillis) todaysSnipeTime
       else todaysSnipeTime.plusDays(1)
 
-    val millisUntilTomorrow = nextSnipeTime.getMillis - DateTime.now.getMillis - 1000
+    val millisUntilTomorrow = nextSnipeTime.getMillis - DateTime.now.getMillis - 2000
     val hoursRemaining      = millisUntilTomorrow / 1000 / 60 / 60
     val minutesRemaining    = millisUntilTomorrow / 1000 / 60 - hoursRemaining * 60
     val secondsRemaining =


### PR DESCRIPTION
In testing out the bot, I noticed that sometimes reservations actually become available ever so slightly before the hour. So updated the bot to snipe slightly earlier for a better chance at grabbing a reservation.

- [x] Updated bot to now snipe two seconds earlier instead of one second earlier