### PR TITLE
feat: add fail-safe when providing empty table type

### DIFF
--- a/src/main/scala/com/resy/ResyClient.scala
+++ b/src/main/scala/com/resy/ResyClient.scala
@@ -187,8 +187,8 @@ class ResyClient(resyApi: ResyApi) extends Logging {
   ): Try[String] = {
     val results = reservationMap.get(resTimeTypes.head.reservationTime).flatMap { tableTypes =>
       resTimeTypes.head.tableType match {
-        case Some(tableType) => tableTypes.get(tableType.toLowerCase)
-        case None            => Some(tableTypes.head._2)
+        case Some(tableType) if tableType.nonEmpty => tableTypes.get(tableType.toLowerCase)
+        case _            => Some(tableTypes.head._2)
       }
     }
 

--- a/src/main/scala/com/resy/ResyClient.scala
+++ b/src/main/scala/com/resy/ResyClient.scala
@@ -188,7 +188,7 @@ class ResyClient(resyApi: ResyApi) extends Logging {
     val results = reservationMap.get(resTimeTypes.head.reservationTime).flatMap { tableTypes =>
       resTimeTypes.head.tableType match {
         case Some(tableType) if tableType.nonEmpty => tableTypes.get(tableType.toLowerCase)
-        case _            => Some(tableTypes.head._2)
+        case _                                     => Some(tableTypes.head._2)
       }
     }
 

--- a/src/test/scala/com/resy/ResyClientSpec.scala
+++ b/src/test/scala/com/resy/ResyClientSpec.scala
@@ -92,10 +92,10 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
       partySize = resDetails.partySize,
       venueId   = resDetails.venueId,
       resTimeTypes = Seq(
-        ReservationTimeType("17:00:00", "")
+        ReservationTimeType("18:00:00", "")
       ),
       millisToRetry = (.1 seconds).toMillis
-    ) shouldEqual Success("CONFIG_ID2")
+    ) shouldEqual Success("CONFIG_ID5")
   }
 
   it should "find an available reservation with no table type preference" in new Fixture {

--- a/src/test/scala/com/resy/ResyClientSpec.scala
+++ b/src/test/scala/com/resy/ResyClientSpec.scala
@@ -83,6 +83,21 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
     ) shouldEqual Success("CONFIG_ID5")
   }
 
+  it should "find an available reservation with empty string as the table type" in new Fixture {
+    when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
+      .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
+
+    resyClient.findReservations(
+      date = resDetails.date,
+      partySize = resDetails.partySize,
+      venueId = resDetails.venueId,
+      resTimeTypes = Seq(
+        ReservationTimeType("17:00:00", "")
+      ),
+      millisToRetry = (.1 seconds).toMillis
+    ) shouldEqual Success("CONFIG_ID2")
+  }
+
   it should "find an available reservation with no table type preference" in new Fixture {
     when(resyApi.getReservations(resDetails.date, resDetails.partySize, resDetails.venueId))
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))

--- a/src/test/scala/com/resy/ResyClientSpec.scala
+++ b/src/test/scala/com/resy/ResyClientSpec.scala
@@ -88,9 +88,9 @@ class ResyClientSpec extends AnyFlatSpec with Matchers {
       .thenReturn(Future(Source.fromResource("getReservations.json").mkString))
 
     resyClient.findReservations(
-      date = resDetails.date,
+      date      = resDetails.date,
       partySize = resDetails.partySize,
-      venueId = resDetails.venueId,
+      venueId   = resDetails.venueId,
       resTimeTypes = Seq(
         ReservationTimeType("17:00:00", "")
       ),


### PR DESCRIPTION
Added a fail-safe so that providing an empty string table type is the same as not providing a table type at all. People have mistaken passing an empty string table type as not specifying a table type at all. This makes it such that the bot behaves the same way, preventing user error.

- [x] Empty string table type is the same as no table type
- [x] Added respective unit test 