### PR TITLE
bot modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,61 +4,80 @@
 [![Ko-fi](https://img.shields.io/badge/support_me_on_ko--fi-F16061?style=plastic&logo=kofi&logoColor=F5F5F5)](https://ko-fi.com/Alkaar)
 
 # resy-booking-bot
+
 ## Introduction
-This is a reservation booking bot designed to snipe reservations from [Resy](https://resy.com/) using the 
-[Resy API](http://subzerocbd.info/). New reservations usually become available on a daily basis. Some restaurants may 
-vary on what time and how many days out reservations are made available. When running the bot, it will sleep until the 
-specified time and wake up to try to snipe a reservation. It will attempt to grab a reservation for a couple of 
+
+This is a reservation booking bot designed to snipe reservations from [Resy](https://resy.com/) using the
+[Resy API](http://subzerocbd.info/). New reservations usually become available on a daily basis. Some restaurants may
+vary on what time and how many days out reservations are made available. When running the bot, it will sleep until the
+specified time and wake up to try to snipe a reservation. It will attempt to grab a reservation for a couple of
 seconds and shutdown, outputting whether is it was or wasn't successful in getting a reservation.
 
 ## Usage
-You need to provide a few values before running the bot.  You can set these parameters in the `resyConfig.conf` file 
-which is located in the `resources` folder. There are comments above the properties with what needs to be provided 
+
+You need to provide a few values before running the bot. You can set these parameters in the `resyConfig.conf` file
+which is located in the `resources` folder. There are comments above the properties with what needs to be provided
 before it can be used, but I'll list it here as well for clarity.
-* **apiKey** - Your user profile API key. Can be found once you're logged into Resy in most `api.resy.com` network 
-calls (i.e. Try they `/find` API call when visiting a restaurant). Open your web console and look for a request header 
-called `authorization`.
-* **auth_token** - Your user profile authentication token when logging into Resy. Can be found once you're logged into 
-Resy in most `api.resy.com` network calls (i.e. Try the `/find` API call when visiting a restaurant). Open your web 
-console and look for a request header called `x-resy-auth-token`.
-* **date** - The date you want to make the reservation in YYYY-MM-DD format. This should be set to the day after the 
-last available day with restaurant reservations as this is the day you want to snipe for a reservation once they 
-become available.
-* **partySize** - Size of the party reservation
-* **venueId** - The unique identifier of the restaurant you want to make the reservation at. Can be found when viewing 
-available reservations for a restaurant as a query parameter in the `/find` API call if you have the web console open.
-* **resTimeTypes** - Priority list of reservation times and table types. Time is in military time HH:MM:SS format. This 
-allows full flexibility on your reservation preferences. For example, your priority order of reservations can be...
-  * 18:00 - Dining Room
-  * 18:00 - Patio
-  * 18:15
 
-  If you have no preference on table type, then simply don't set it and the bot will pick a reservation for that time 
+- **apiKey** - Your user profile API key. Can be found once you're logged into Resy in most `api.resy.com` network
+  calls (i.e. Try they `/find` API call when visiting a restaurant). Open your web console and look for a request header
+  called `authorization`.
+- **auth_token** - Your user profile authentication token when logging into Resy. Can be found once you're logged into
+  Resy in most `api.resy.com` network calls (i.e. Try the `/find` API call when visiting a restaurant). Open your web
+  console and look for a request header called `x-resy-auth-token`.
+- **date** - The date you want to make the reservation in YYYY-MM-DD format. This should be set to the day after the
+  last available day with restaurant reservations as this is the day you want to snipe for a reservation once they
+  become available.
+- **partySize** - Size of the party reservation
+- **venueId** - The unique identifier of the restaurant you want to make the reservation at. Can be found when viewing
+  available reservations for a restaurant as a query parameter in the `/find` API call if you have the web console open.
+- **resTimeTypes** - Priority list of reservation times and table types. Time is in military time HH:MM:SS format. This
+  allows full flexibility on your reservation preferences. For example, your priority order of reservations can be...
+
+  - 18:00 - Dining Room
+  - 18:00 - Patio
+  - 18:15
+
+  If you have no preference on table type, then simply don't set it and the bot will pick a reservation for that time
   slot regardless of the table type.
-* **hour** - Hour of the day when reservations become available and when you want to snipe
-* **minute** - Minute of the day when reservations become available and when you want to snipe
 
-Lastly, remember to have a credit card on file in your account. Some reservations require a credit card before making 
+- **runDetails** - Details of how you want to run the bot.
+
+  - **mode** - Mode of the bot. Can be either `once`, `scheduled`, or `loop`.
+    - **once** - Will run the bot once and attempt to snipe a reservation.
+    - **scheduled** - Will schedule the bot to snipe a reservation.
+    - **loop** - Will retry to snipe a reservation in a loop.
+  - **scheduled** - Schedule of when you want to run the bot. Only used if `mode` is set to `schedule`.
+    - **hour** - Hour of the day when reservations become available and when you want to snipe
+    - **minute** - Minute of the day when reservations become available and when you want to snipe
+  - **loop** - Loop settings for when you want to run the bot. Only used if `mode` is set to `loop`.
+    - **interval** - Interval in seconds between each retry
+    - **maxRetries** - Maximum number of retries before shutting down the bot. Set to `-1` for infinite retries.
+
+Lastly, remember to have a credit card on file in your account. Some reservations require a credit card before making
 a reservation in case of late cancellations or no-shows. Not having one will result in the snipe to fail!
 
 ## How it works
-The main entry point of the bot is in the `ResyBookingBot` object under the `main` function. It utilizes the arguments 
-which you need to provide in the `resyConfig.conf` file, located in the `resources` folder.  The bot runs based on the 
-local time of the machine it's running on. Upon running the bot, it will automatically sleep until the specified time. 
-At the specified time, it will wake up and attempt to query for reservations for 10 seconds. This is because sometimes 
-reservations are not available exactly at the same time every day so 10 seconds is to allow for some buffer. Once 
-reservation times are retrieved, it will try to find the best available time slot given your priority list of 
-reservation times. If a time can't be booked, the bot will shutdown here. If a time can be booked, it will make an 
-attempt to snipe it. If a reservation couldn't be booked, and it's still within 10 seconds of the original start time, 
-it will restart the whole workflow and try to find another available reservation. In the event it was unable to get any 
+
+The main entry point of the bot is in the `ResyBookingBot` object under the `main` function. It utilizes the arguments
+which you need to provide in the `resyConfig.conf` file, located in the `resources` folder. The bot runs based on the
+local time of the machine it's running on. Upon running the bot, it will automatically sleep until the specified time.
+At the specified time, it will wake up and attempt to query for reservations for 10 seconds. This is because sometimes
+reservations are not available exactly at the same time every day so 10 seconds is to allow for some buffer. Once
+reservation times are retrieved, it will try to find the best available time slot given your priority list of
+reservation times. If a time can't be booked, the bot will shutdown here. If a time can be booked, it will make an
+attempt to snipe it. If a reservation couldn't be booked, and it's still within 10 seconds of the original start time,
+it will restart the whole workflow and try to find another available reservation. In the event it was unable to get any
 reservations, the bot will automatically shutdown.
 
 ## Running the bot
-There are a multitude of ways to run it, but I'll share the two most 
+
+There are a multitude of ways to run it, but I'll share the two most
 common ways:
-- You can use the `Run` button in IntelliJ. It may automatically be able to find the main class. If not, you have to 
-configure it to look under `com.resy.ResyBookingBot`.
+
+- You can use the `Run` button in IntelliJ. It may automatically be able to find the main class. If not, you have to
+  configure it to look under `com.resy.ResyBookingBot`.
 - You can run it via `sbt`. I would recommend doing this via CLI instead of inside IntelliJ. Type `sbt` to start the  
-sbt instance, then type `run`. It will have some output then bring you back to the sbt prompt. Do not exit out of the 
-sbt prompt as this will kill the bot. The bot is running inside the sbt instance and will wake up at the appropriate 
-time to snipe a reservation.
+  sbt instance, then type `run`. It will have some output then bring you back to the sbt prompt. Do not exit out of the
+  sbt prompt as this will kill the bot. The bot is running inside the sbt instance and will wake up at the appropriate
+  time to snipe a reservation.

--- a/src/main/resources/log4j2.properties
+++ b/src/main/resources/log4j2.properties
@@ -6,4 +6,4 @@ rootLogger.appenderRef.stdout.ref = Stdout
 appender.console.type = Console
 appender.console.name = Stdout
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = [%-5level] %d{yyyy-MM-dd HH:mm:ss.SSSXXX} %c{1}:%L - %msg%n
+appender.console.layout.pattern = [%-5level] %highlight{%d{yyyy-MM-dd HH:mm:ss.SSSXXX}} %cyan{%c{1}:%L} - %msg%n

--- a/src/main/resources/resyConfig.conf
+++ b/src/main/resources/resyConfig.conf
@@ -48,13 +48,34 @@ resDetails.venue-id=
 resDetails.res-time-types=
 
 #############
-# SnipeTime #
+# mode #
+#############
+# The mode the bot will run in. Can be either "once", "scheduled", or "loop".
+#   * "once" - The bot will run once and exit.
+#   * "scheduled" - The bot will run once and then wait until the scheduled time to run again.
+#   * "loop" - The bot will run once and then wait until the retry time to run again.
+runDetails.mode=
+
+#############
+# scheduled #
 #############
 # Hour of the day when reservations become available and when you want to snipe
 # e.g.
-# snipeTime.hours=9
-snipeTime.hours=
+# runDetails.scheduled.hours=9
+runDetails.scheduled.hours=
 # Minute of the day when reservations become available and when you want to snipe
 # e.g.
-# snipeTime.minutes=0
-snipeTime.minutes=
+# runDetails.scheduled.minutes=0
+runDetails.scheduled.minutes=
+
+#############
+# loop #
+#############
+# How much time between retries in seconds.
+# e.g.
+# runDetails.loop.interval=5
+runDetails.loop.interval=
+# How many times to retry before giving up. Set to -1 to retry indefinitely.
+# e.g.
+# runDetails.loop.max-retries=5
+runDetails.loop.max-retries=

--- a/src/main/scala/com/resy/ResyBookingBot.scala
+++ b/src/main/scala/com/resy/ResyBookingBot.scala
@@ -5,6 +5,7 @@ import org.apache.logging.log4j.scala.Logging
 import org.joda.time.DateTime
 import pureconfig.ConfigSource
 import pureconfig.generic.auto._
+import scala.util.Success
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
@@ -18,40 +19,76 @@ object ResyBookingBot extends Logging {
     val resyConfig = ConfigSource.resources("resyConfig.conf")
     val resyKeys   = resyConfig.at("resyKeys").loadOrThrow[ResyKeys]
     val resDetails = resyConfig.at("resDetails").loadOrThrow[ReservationDetails]
-    val snipeTime  = resyConfig.at("snipeTime").loadOrThrow[SnipeTime]
+    val runDetails = resyConfig.at("runDetails").loadOrThrow[RunDetails]
 
     val resyApi             = new ResyApi(resyKeys)
     val resyClient          = new ResyClient(resyApi)
     val resyBookingWorkflow = new ResyBookingWorkflow(resyClient, resDetails)
 
-    val system      = ActorSystem("System")
-    val dateTimeNow = DateTime.now
-    val todaysSnipeTime = dateTimeNow
-      .withHourOfDay(snipeTime.hours)
-      .withMinuteOfHour(snipeTime.minutes)
-      .withSecondOfMinute(0)
-      .withMillisOfSecond(0)
-
-    val nextSnipeTime =
-      if (todaysSnipeTime.getMillis > dateTimeNow.getMillis) todaysSnipeTime
-      else todaysSnipeTime.plusDays(1)
-
-    val millisUntilTomorrow = nextSnipeTime.getMillis - DateTime.now.getMillis - 2000
-    val hoursRemaining      = millisUntilTomorrow / 1000 / 60 / 60
-    val minutesRemaining    = millisUntilTomorrow / 1000 / 60 - hoursRemaining * 60
-    val secondsRemaining =
-      millisUntilTomorrow / 1000 - hoursRemaining * 60 * 60 - minutesRemaining * 60
-
-    logger.info(s"Next snipe time: $nextSnipeTime")
-    logger.info(
-      s"Sleeping for $hoursRemaining hours, $minutesRemaining minutes, and $secondsRemaining seconds"
-    )
-
-    system.scheduler.scheduleOnce(millisUntilTomorrow millis) {
+    if (runDetails.mode == "once") {
+      logger.info("Running snipe once")
       resyBookingWorkflow.run()
+    }
 
-      logger.info("Shutting down Resy Booking Bot")
-      System.exit(0)
+    if (runDetails.mode == "scheduled") {
+      logger.info("Setting up scheduled snipe")
+      val system      = ActorSystem("System")
+      val dateTimeNow = DateTime.now
+      val todaysSnipeTime = dateTimeNow
+        .withHourOfDay(runDetails.scheduled.hours)
+        .withMinuteOfHour(runDetails.scheduled.minutes)
+        .withSecondOfMinute(0)
+        .withMillisOfSecond(0)
+
+      val nextSnipeTime =
+        if (todaysSnipeTime.getMillis > dateTimeNow.getMillis) todaysSnipeTime
+        else todaysSnipeTime.plusDays(1)
+
+      val millisUntilTomorrow = nextSnipeTime.getMillis - DateTime.now.getMillis - 2000
+      val hoursRemaining      = millisUntilTomorrow / 1000 / 60 / 60
+      val minutesRemaining    = millisUntilTomorrow / 1000 / 60 - hoursRemaining * 60
+      val secondsRemaining =
+        millisUntilTomorrow / 1000 - hoursRemaining * 60 * 60 - minutesRemaining * 60
+
+      logger.info(s"Next snipe time: $nextSnipeTime")
+      logger.info(
+        s"Sleeping for $hoursRemaining hours, $minutesRemaining minutes, and $secondsRemaining seconds"
+      )
+
+      system.scheduler.scheduleOnce(millisUntilTomorrow millis) {
+        resyBookingWorkflow.run()
+
+        logger.info("Shutting down Resy Booking Bot")
+        System.exit(0)
+      }
+    }
+
+    if (runDetails.mode == "loop") {
+      logger.info("Starting snipe loop")
+      val system = ActorSystem("System")
+
+      val maxRetries = runDetails.loop.maxRetries
+      var retries    = 0
+
+      system.scheduler.schedule(0 seconds, runDetails.loop.interval seconds) {
+        val res = resyBookingWorkflow.run()
+
+        res match {
+          case Success(_) =>
+            logger.info("Shutting down Resy Booking Bot")
+            System.exit(0)
+          case _ =>
+        }
+
+        retries += 1
+        if (retries == maxRetries) {
+          logger.info(s"Max retries reached: $maxRetries")
+          logger.info("Shutting down Resy Booking Bot")
+          System.exit(0)
+        }
+
+        logger.info(s"Retrying in ${runDetails.loop.interval} seconds...")
+      }
     }
   }
 }

--- a/src/main/scala/com/resy/ResyConfig.scala
+++ b/src/main/scala/com/resy/ResyConfig.scala
@@ -18,4 +18,11 @@ object ReservationTimeType {
   }
 }
 
-final case class SnipeTime(hours: Int, minutes: Int)
+final case class RunDetails(
+  mode: String,
+  scheduled: Scheduled,
+  loop: Loop)
+
+final case class Scheduled(hours: Int, minutes: Int)
+
+final case class Loop(interval: Int, maxRetries: Int)


### PR DESCRIPTION
add run modes
- once
- scheduled (formerly snipe)
- loop

Readme is updated with instructions.

I know you said in one of your previous prs that you don't want the resy endpoint to get hammered with a loop feature, and I agree. But at the same time I'm praying that the engineers over at resy have added rate limiting and token expiration to their systems because sooner or later some chatgpt enabled dev is probably going to ask it to write a mega bot that retries resy/opentable/tock apis endlessly and then,,, they will definitely need rate limiting.

I think this feature is a no brainer but I will happily leave it up to you to decide whether or not it should be merged.

But also, I did manage to snag a hard resy within 5 mins of testing the bot on loop :)