### PR TITLE
fix: add missing referer header

### DIFF
--- a/src/main/scala/com/resy/ResyApi.scala
+++ b/src/main/scala/com/resy/ResyApi.scala
@@ -108,7 +108,8 @@ object ResyApi extends Logging {
       .withHttpHeaders(
         createHeaders(resyKeys) ++ Seq(
           "Content-Type" -> "application/x-www-form-urlencoded",
-          "origin"       -> "https://widgets.resy.com/"
+          "Origin"       -> "https://widgets.resy.com",
+          "Referer"      -> "https://widgets.resy.com/"
         ): _*
       )
       .post(post)


### PR DESCRIPTION
The final booking post request now needs a referer header or else it fails with an Internal Server Error.

- [x] add referer header to post request